### PR TITLE
Update to version 0.29.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "python-language-server" %}
-{% set version = "0.29.1" %}
+{% set version = "0.29.2" %}
 {% set hash_type = "sha256" %}
-{% set hash = "430335f7ef8d9b446bac6daa858133b4c5e710bd39c25f1d3e7a4803a9a318b9" %}
+{% set hash = "cd08661e3d51916e38868c2ba5ebd1d0cc182d4c8ba2b1643260e7f76377620e" %}
 
 package:
   name: {{ name|lower }}
@@ -16,7 +16,6 @@ build:
   script: {{ PYTHON }} -m pip install . --no-deps -vv
   entry_points:
     - pyls = pyls.__main__:main
-    # This recipe has pyls entrypoints
 
 requirements:
   host:
@@ -24,9 +23,9 @@ requirements:
     - pip
   run:
     - configparser  # [py27]
-    - futures       # [py27]     
-    - future >=0.14
-    - jedi >=0.15,<0.16
+    - future >=0.14  # [py27]
+    - backports.functools_lru_cache  # [py27]
+    - jedi >=0.14.1,<0.16
     - python-jsonrpc-server >=0.1.0
     - pycodestyle
     - pydocstyle >=2.0.0


### PR DESCRIPTION
Also add a missing dependency on backports.functools_lru_cache for Python 2

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

@conda-forge-admin, please rerender